### PR TITLE
🔧 긴급수정: Upstash Redis 연결 복구

### DIFF
--- a/app/api/chat/rooms/[roomId]/route.ts
+++ b/app/api/chat/rooms/[roomId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getRoomData, addUserToRoom, addMessageToRoom, removeUserFromRoom } from '@/lib/redis-mock';
+import { getRoomData, addUserToRoom, addMessageToRoom, removeUserFromRoom } from '@/lib/redis';
 
 interface RouteParams {
   params: Promise<{ roomId: string }>;


### PR DESCRIPTION
## 🚨 긴급 수정: 채팅 기능 완전 복구

### 문제
- API 라우트에서 `redis-mock` 사용으로 서버리스 환경에서 데이터 손실
- 403 Forbidden 에러 및 사용자 동기화 실패
- 메시지 전송 불가 ("방에 참여하지 않은 사용자입니다")

### 해결
- ✅ API 라우트에서 실제 Upstash Redis 사용
- ✅ 로컬 환경변수 실제 Redis 정보로 업데이트
- ✅ 빌드 성공 확인

### 추가 필요 작업
- [ ] Vercel 환경변수 설정 (UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)